### PR TITLE
Update network.tf

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -39,16 +39,6 @@ resource "aws_subnet" "public-us-east-1b" {
   vpc_id = "${aws_vpc.imaging.id}"
 }
 
-resource "aws_subnet" "public-us-east-1c" {
-  availability_zone = "us-east-1c"
-  cidr_block = "10.0.3.0/24"
-  map_public_ip_on_launch = true
-  tags {
-    Name = "imaging-public-us-east-1c"
-  }
-  vpc_id = "${aws_vpc.imaging.id}"
-}
-
 resource "aws_subnet" "public-us-east-1d" {
   availability_zone = "us-east-1d"
   cidr_block = "10.0.4.0/24"
@@ -73,15 +63,6 @@ resource "aws_subnet" "private-us-east-1b" {
   cidr_block = "10.0.6.0/24"
   tags {
     Name = "imaging-private-us-east-1b"
-  }
-  vpc_id = "${aws_vpc.imaging.id}"
-}
-
-resource "aws_subnet" "private-us-east-1c" {
-  availability_zone = "us-east-1c"
-  cidr_block = "10.0.7.0/24"
-  tags {
-    Name = "imaging-private-us-east-1c"
   }
   vpc_id = "${aws_vpc.imaging.id}"
 }


### PR DESCRIPTION
 Subnets can currently only be created in the following availability zones: us-east-1a, us-east-1b, us-east-1d, us-east-1e.